### PR TITLE
added TokenAuth DFR settings

### DIFF
--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -38,6 +38,7 @@ INSTALLED_APPS = [
     "django_extensions",
     # "django_sql_dashboard",
     "rest_framework",
+    "rest_framework.authtoken",
     # our apps
     "jobs",
     "users",
@@ -201,6 +202,7 @@ REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": [
         "rest_framework.authentication.BasicAuthentication",
         "rest_framework.authentication.SessionAuthentication",
+        "rest_framework.authentication.TokenAuthentication",
     ],
     "DEFAULT_FILTER_BACKENDS": ["rest_framework.filters.OrderingFilter"],
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.CursorPagination",


### PR DESCRIPTION
This seems to be working. I generated a token for the `kojo@revsys.com` user and that token works with 
```curl -X GET http://127.0.0.1:8000/apis/ -H 'Authorization: Token {token_I_generated_in_django_admin}'```

But when  set `SCC_API_TOKEN` in the CLI app, the CLI app doesn't work. 